### PR TITLE
fix: 상세페이지 엔터 적용안됨 수정

### DIFF
--- a/src/components/organisms/ItemDetails/styled.ts
+++ b/src/components/organisms/ItemDetails/styled.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Body1Wrapper } from "components/atoms/Text/styled";
+import { DescRegularWrapper } from "components/atoms/Text/styled";
 import { IconWithTextWrapper } from "components/molecules/IconWithText/styled";
 
 export const CategoryWrapper: ReturnType<typeof styled.div> = styled.div`
@@ -17,7 +17,7 @@ export const ItemDetailsHeader: ReturnType<typeof styled.div> = styled.div`
 `;
 
 export const DescriptionWrapper: ReturnType<typeof styled.div> = styled.div`
-  ${Body1Wrapper} {
+  ${DescRegularWrapper} {
     white-space: break-spaces;
   }
 `;


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #393

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->

ItemDetails 컴포넌트의 DescriptionWrapper에 작성된 스타일을 수정했습니다.

- text wrapper 컴포넌트를 Body1Wrapper에서 DescRegularWrapper로 변경

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

| 수정 전 | 수정 후 |
|--|--|
| ![image](https://github.com/user-attachments/assets/8c0c6c5f-da4a-4e45-abd0-340b9aa5aebb) | ![image](https://github.com/user-attachments/assets/3e2e55bc-6779-4cbe-80c2-efa7a70d61fd) |
