### PR TITLE
fix: build.sh 디렉토리 명 변경

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,10 +7,10 @@ ls -la
 
 # output 디렉토리 생성
 mkdir -p output
-cp -R ./WEB1_1_J1P5_FE/* ./output
-cp -R ./WEB1_1_J1P5_FE/.storybook ./output
+cp -R ./Meerket_FE/* ./output
+cp -R ./Meerket_FE/.storybook ./output
 
-cp -R ./output ./WEB1_1_J1P5_FE/
+cp -R ./output ./Meerket_FE/
 
 
 


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #395 

## 💭 작업 내용
레포 이관으로 인해  build.sh 파일에 있던 폴더명이 기존 레포이름을 따라가고 있어서 생기는 문제였습니다.
해당 부분 수정하는 PR입니다.

<!-- 작업한 내용을 간단히 설명해주세요 -->

## 🤔 참고 사항
없습니다.
<!-- 참고 사항을 설명해주세요 -->

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/82db8491-02e8-4176-b6b5-e3b57e7dbcca)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
