### PR TITLE
Fix/#399

### DIFF
--- a/src/hooks/useFetchSession.ts
+++ b/src/hooks/useFetchSession.ts
@@ -10,7 +10,7 @@ export const useFetchSession = () => {
     retry: false,
   });
   return {
-    sessionUser: data,
+    sessionUser: isError ? null : data,
     isLoading,
     isError,
   };

--- a/src/pages/guards/LoginGuard.tsx
+++ b/src/pages/guards/LoginGuard.tsx
@@ -10,13 +10,13 @@ interface ILoginGuardProps {
  * 로그인한 사용자가 로그인 페이지 접근 시 처리
  */
 export const LoginGuard = ({ children }: ILoginGuardProps) => {
-  const { sessionUser, isLoading } = useFetchSession();
+  const { sessionUser, isLoading, isError } = useFetchSession();
 
   if (isLoading) {
     return null;
   }
 
-  if (sessionUser) {
+  if (!isError && sessionUser) {
     return <Navigate to="/" replace />;
   }
 

--- a/src/pages/guards/LoginGuard.tsx
+++ b/src/pages/guards/LoginGuard.tsx
@@ -10,13 +10,13 @@ interface ILoginGuardProps {
  * 로그인한 사용자가 로그인 페이지 접근 시 처리
  */
 export const LoginGuard = ({ children }: ILoginGuardProps) => {
-  const { sessionUser, isLoading, isError } = useFetchSession();
+  const { sessionUser, isLoading } = useFetchSession();
 
   if (isLoading) {
     return null;
   }
 
-  if (!isError && sessionUser) {
+  if (sessionUser) {
     return <Navigate to="/" replace />;
   }
 

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -29,10 +29,10 @@ export const useUserStore: UseBoundStore<StoreApi<UserState>> = create(
             }
           })
         );
-      }
+      },
     }),
     {
-      name: localStorageKey
+      name: localStorageKey,
     }
   )
 );


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #399 

## 💭 작업 내용

### 무한 리다이렉트가 일어나는 과정 정리


(1) 크롬에서 A탭, B탭을 엽니다.
(2) A탭에서 로그인을 합니다.
(3) B탭을 확인하면 자동으로 로그인되서 메인 페이지로 이동한다.
B탭 기준으로(3) 과정을 수행하면 LoginGuard 에서 GET /api/v1/users/session 이 요청을 보냅니다.
이 요청이 성공적인 경우 아래 값을 리턴 받고,  "/" 로 리다이렉트 시킵니다.
{
    "nickname": "string",
    "imageUrl": "string",
    "ActivityEmdName": "string"    
}

(4) B탭의 마이페이지에서 로그아웃을 눌러서 로그아웃을 합니다.
(5) B탭 기준 정상적으로 로그아웃이 됩니다. (쿠키에서 SessionID를 삭제)
(6) A탭으로 돌아오면 A탭의 AuthGuard에서 GET /api/v1/users/session 요청을 보냅니다.
(7) 백엔드에서는 쿠키에 SessionID가 없으니깐 에러 리턴합니다.
(8) A탭의 AuthGuard에서 에러를 탐지(isError = true 가 됨) 
(9) A탭의 AuthGuard에서 isError가 true면 Login페이지로 리다이렉트합니다.
(10) A탭에서 이동한 LoginPage에서는 LoginGuard 가 GET /api/v1/users/session 이 요청을 보냄.
(11) 백엔드에서는 쿠키에 SessionID가 없으니깐 에러 리턴
(12) A탭의 LoginGuard에서 에러가 나지만 이전 data 값을 그대로 가지고 있기에 아래 값이(sessionUser) 유효해서 "/" 로 리다이렉트 시킵니다. 
    "nickname": "string",
    "imageUrl": "string",
    "ActivityEmdName": "string"
![image](https://github.com/user-attachments/assets/311bff4b-eee3-4035-b9c7-172ff83d5053)

이렇게 되면 (6)~(11) 과정이 무한 반복되서 버그가 일어납니다.

### 해결 방법

해결 방법은 단순합니다. 
기존 sessionUser 가 data 만 리턴 했던 부분을 isError? 인 경우에 null 을 아닌 경우에만 data로 리턴하는 식으로 해결했습니다. 
```
// sessionUser: data, 를 아래로 변경
sessionUser: isError ? null : data,
```

### (12) 번에서 이전 data값을 그대로 가지고 있는 이유
(12) 번에서 LoginGuard가 에러가 나지만 이전 data 값을 그대로 가지고 있는 이유는 
react-query가 SWR (Stale-While-Revalidate) 라는 캐시 방식을 채택하고 있기 때문입니다.

SWR은 react-query가, staleTime이 지난 상태이더라도, 
있는 데이터를 먼저 보여주면서 새로운 데이터로 갱신한다는 뜻입니다.

저희가 사용하는 react-query의 경우 staleTime이 기본 0으로 설정되어 있는데,
이러면 Fetch 하는 동안 이전의 값을 보여주고, Fetch 이후 값을 교체해주는 방식으로 돌아갑니다. 

그런데 현재 서버가 계속 에러를 뱉고 있기 때문에 데이터 교체가 일어나지 않고 있습니다.
이 당시 isLoading, isFetching, isError 를 콘솔에 찍어보면 아래 이미지와 같습니다.

![image](https://github.com/user-attachments/assets/59f7e5bd-8f9f-4626-9321-aae982e6d91d)

isLoading은 현재 캐시된 데이터가 없고 최초로 가져오는 동안에 true로 표시됩니다.
isFetching은 데이터를 가져오는 동안에는 true로 표시됩니다.
현재 사진에는 isLoading은 false이고, isFetching은 true가 되어있습니다.
이 말은 현재 캐시된 데이터가 있다는 뜻입니다. 
그래서 (12)번에서 이전 data값을 그대로 가지고 있습니다.

<!-- 작업한 내용을 간단히 설명해주세요 -->

## 🤔 참고 사항
참조 글 react-query swr 과 관련한 글
https://blog.bcsdlab.com/front-end/react/react-query/
<!-- 참고 사항을 설명해주세요 -->

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
