### PR TITLE
refactor: 빌드 최적화 및 코드 스플리팅 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "eslint-plugin-storybook": "^0.11.1",
+    "rollup-plugin-visualizer": "^5.14.0",
     "storybook": "8.4.4",
     "typescript": "~5.6.2",
     "vite": "^5.4.10"

--- a/src/components/atoms/Select/index.tsx
+++ b/src/components/atoms/Select/index.tsx
@@ -1,7 +1,12 @@
-import ReactSelect from "react-select";
+import React, { Suspense } from "react";
+//import ReactSelect from "react-select";
 import { SelectWrapper } from "./styled";
 import type { ISelectOption } from "types";
 
+// eslint-disable-next-line @rushstack/typedef-var
+const ReactSelect = React.lazy(() =>
+  import("react-select").then((module) => ({ default: module.default }))
+);
 interface ISelectProps {
   /** Select의 id */
   id?: string;
@@ -23,21 +28,25 @@ export const Select = ({
   value,
   onChange,
   options,
-  placeholder = "선택해주세요"
+  placeholder = "선택해주세요",
 }: ISelectProps) => {
   return (
     <SelectWrapper>
-      <ReactSelect
-        id={id}
-        name={name}
-        classNamePrefix="rs"
-        placeholder={placeholder}
-        value={value}
-        onChange={(selected) => onChange(selected || undefined)}
-        options={options}
-        // 검색 옵션 제거
-        isSearchable={false}
-      />
+      <Suspense fallback={<div>Loading...</div>}>
+        <ReactSelect
+          id={id}
+          name={name}
+          classNamePrefix="rs"
+          placeholder={placeholder}
+          value={value}
+          onChange={(selected) =>
+            onChange((selected as ISelectOption) || undefined)
+          }
+          options={options}
+          // 검색 옵션 제거
+          isSearchable={false}
+        />
+      </Suspense>
     </SelectWrapper>
   );
 };

--- a/src/components/molecules/ImageSlider/index.tsx
+++ b/src/components/molecules/ImageSlider/index.tsx
@@ -1,8 +1,18 @@
-import { Swiper, SwiperSlide } from "swiper/react";
-import { Pagination } from "swiper/modules";
+import React, { Suspense } from "react";
 import { Image } from "components/atoms";
+import { Loading } from "../Loading";
 import { ImageSliderWrapper } from "./styled";
+import { Pagination } from "swiper/modules";
 import "swiper/swiper-bundle.css";
+// Swiper 컴포넌트를 지연 로딩
+// eslint-disable-next-line @rushstack/typedef-var
+const Swiper = React.lazy(() =>
+  import("swiper/react").then((module) => ({ default: module.Swiper }))
+);
+// eslint-disable-next-line @rushstack/typedef-var
+const SwiperSlide = React.lazy(() =>
+  import("swiper/react").then((module) => ({ default: module.SwiperSlide }))
+);
 
 // TODO: import 오류 해결하기
 // import "swiper/css";
@@ -17,20 +27,21 @@ interface IImageSliderProps {
 export const ImageSlider = ({ imgUrls }: IImageSliderProps) => {
   return (
     <ImageSliderWrapper>
-      <Swiper
-        pagination={{
-          type: "fraction"
-        }}
-        modules={[Pagination]}
-        className="image-slider"
-      >
-        {imgUrls.map((url, index) => (
-          <SwiperSlide key={index}>
-            <Image url={url} />
-          </SwiperSlide>
-        ))}
-      </Swiper>
+      <Suspense fallback={<Loading />}>
+        <Swiper
+          pagination={{
+            type: "fraction",
+          }}
+          modules={[Pagination]}
+          className="image-slider"
+        >
+          {imgUrls.map((url, index) => (
+            <SwiperSlide key={index}>
+              <Image url={url} />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </Suspense>
     </ImageSliderWrapper>
   );
 };
-

--- a/src/pages/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage.tsx
@@ -7,7 +7,7 @@ import { TopSheet } from "components/templates/ChatRoomTemplate/TopSheet";
 import { DEFAULT_IMG_PATH } from "constants/imgPath";
 import { useChatGroups } from "hooks/useChatGroups";
 import { useWebSocket } from "hooks/useWebSocket";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { http } from "services/api";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { visualizer } from "rollup-plugin-visualizer";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -9,8 +10,13 @@ export default defineConfig({
       plugins: [["@swc/plugin-emotion", {}]],
     }),
     tsconfigPaths(),
+    visualizer({
+      filename: "./dist/report.html",
+      open: false,
+      brotliSize: true,
+    }),
   ],
   define: {
-    "process.env": process.env
-  }
+    "process.env": process.env,
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4161,7 +4161,7 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-open@^8.0.4:
+open@^8.0.4, open@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
   integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
@@ -4591,6 +4591,16 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-visualizer@^5.14.0:
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz#be82d43fb3c644e396e2d50ac8a53d354022d57c"
+  integrity sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==
+  dependencies:
+    open "^8.4.0"
+    picomatch "^4.0.2"
+    source-map "^0.7.4"
+    yargs "^17.5.1"
+
 rollup@^4.20.0:
   version "4.27.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.27.3.tgz#078ecb20830c1de1f5486607f3e2f490269fb98a"
@@ -4751,6 +4761,11 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 stack-generator@^2.0.5:
   version "2.0.10"
@@ -5281,7 +5296,7 @@ yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.7.2:
+yargs@^17.5.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #407 

## 💭 작업 내용

번들 사이즈 최적화 및 코드 스플리팅 작업 진행했습니다.

(1) 저희가 Vite를 사용하기 때문에 빌드 분석 도구로 rollup-plugin-visualizer 를 선택했습니다.
(Vite가 내부적으로 rollup을 빌드 도구로 사용하기 떄문)
(2) 1:1 채팅 페이지에서 스크롤시 fetch delay 주는 용도로 lodash를 사용하고 있는데 이때 lodash 모듈 전체를 가지고 오고 있어 
`import { throttle }  from "lodash"; `  -> `import throttle from "lodash/throttle";` 으로 변경하였습니다. 
(3) 물풍 상세 페이지에서만 사용하는 Swiper 라이브러리에 지연로딩을 적용하였습니다.
(4) 물품 등록/수정 페이지에서만 사용하는 react-select 라이브러리에 지연 로딩을 적용하였습니다.

<!-- 작업한 내용을 간단히 설명해주세요 -->

## 🤔 참고 사항
아래는 최적화 전 번들 사이즈 크기 비교입니다. 
908.95KB -> 687.06KB 
<!-- 참고 사항을 설명 해주세요 -->

## 📸 스크린샷
<img width="329" alt="최적화전크기" src="https://github.com/user-attachments/assets/65e43a87-54b7-43b3-8096-17f57d760339" />

<img width="367" alt="최적화후크기" src="https://github.com/user-attachments/assets/6c74c066-4d8b-4d41-b24a-26c63223d29a" />


<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
