### PR TITLE
fix: PR 코멘트에 에러 로그 보이지 않게 수정

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,6 +16,9 @@ defaults:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -47,12 +50,7 @@ jobs:
 
       - name: Build
         run: |
-          yarn build 2>&1 | tee build.log
-          BUILD_EXIT_CODE=$?
-          if [ $BUILD_EXIT_CODE -ne 0 ]; then
-            echo "빌드에 실패했습니다. PR에 코멘트를 남기고 작업을 실패 처리합니다."
-            exit $BUILD_EXIT_CODE
-          fi
+          yarn build
         id: build
 
       - name: Comment PR
@@ -60,12 +58,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const errorMessage = fs.readFileSync('build.log', 'utf8');
-
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## ❌ 빌드 테스트 실패\n\n빌드 테스트 중 다음과 같은 에러가 발생했습니다:\n<details>\n<summary>에러 로그 보기</summary>\n\`\`\`\n${errorMessage}\n\`\`\`\n</details>\n\n코드를 확인하고 수정해주세요.`
+              body: `## ❌ 빌드 테스트 실패\n\n빌드 테스트 중 에러가 발생했습니다. 로그를 확인하고 수정해주세요!`
             })


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #513

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- 원래는 코멘트에 에러 로그를 첨부했는데, 미트볼 버튼 클릭 시 상세 로그를 볼 수 있어 불필요하다고 생각되어 제거했습니다.

## 🤔 참고 사항

<!-- 참고 사항을 설명해주세요 -->

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
